### PR TITLE
Removing slack calls from jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,6 @@ def failure_function(exception_obj, failureMessage) {
     emailext body: '${DEFAULT_CONTENT}\n\"' + failureMessage + '\"\n\nCheck console output at $BUILD_URL to view the results.',
             recipientProviders: toEmails,
             subject: '${DEFAULT_SUBJECT}'
-    slackSend color: 'danger',
-            message: "${base_container_name}: " + failureMessage
     throw exception_obj
 }
 


### PR DESCRIPTION
### Issue reference / description
Removing the slack calls that were clogging up the Jenkins channel.

## Checklist for submitter

- [ ] Update docker container versions (if possible)
- [ ] Update conan package versions (if possible)
- [ ] Unit tests pass
- [ ] utils/acquire.sh runs
- [ ] utils/daquiri.sh runs
- [ ] MockProducer profile runs and produces plots (manual test)
- [ ] profiles in /data directory have been updated (if applicable)

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
