### PR TITLE
Make first_build.sh work on macOS

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -19,7 +19,7 @@ cmake
 virtualrunenv
 
 [options]
-gtest:shared=True
+gtest:shared=False
 librdkafka:shared=True
 
 [imports]

--- a/utils/first_build.sh
+++ b/utils/first_build.sh
@@ -20,6 +20,10 @@ if [[ $SYSTEM == "centos" ]]; then
           --options boost_system:shared=True boost_filesystem/1.69.0@bincrafters/stable || exit 1
     conan install --build=outdated .. || exit 1
     cmake -DCONAN=MANUAL ..
+elif [[ $SYSTEM == "macos" ]]; then
+    conan install --build=outdated .. || exit 1
+    source ./activate_run.sh
+    cmake -DCONAN=MANUAL ..
 else
     cmake ..
 fi


### PR DESCRIPTION
Use shared gtest library, as the shared library does not have @rpath in
its name, resulting in it not being found on macOS.

### Issue reference / description

JIRA issue DM-1704

## Checklist for submitter

- [ ] Update docker container versions (if possible)
- [ ] Update conan package versions (if possible)
- [ ] Unit tests pass
- [ ] utils/acquire.sh runs
- [ ] utils/daquiri.sh runs
- [ ] MockProducer profile runs and produces plots (manual test)
- [ ] profiles in /data directory have been updated (if applicable)

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel.
